### PR TITLE
Hide validation details by default using Bootstrap theme

### DIFF
--- a/purl_editor.css
+++ b/purl_editor.css
@@ -37,9 +37,7 @@ button:disabled {
 }
 
 #status-area {
-    width: 100%;
-    height: auto;
-    padding: 1em;
+    padding-top: 1em;
 }
 
 h2 {

--- a/purl_editor.css
+++ b/purl_editor.css
@@ -37,11 +37,8 @@ button:disabled {
 }
 
 #status-area {
-    margin-top: 2em;
     width: 100%;
     height: auto;
-    background-color: #F5F5F5;
-    border: 4px groove;
     padding: 1em;
 }
 

--- a/purl_editor.js
+++ b/purl_editor.js
@@ -25,26 +25,26 @@ function showHideText(elemToShow, elemToHide) {
  * Formats a String message as a dismissable Bootstrap alert text.
  * For example, passing parameter style = alert-danger gives a red box.
  */
-function getAlertFor(text, style, extraText='') {
+function showAlertFor(text, style, extraText='') {
+    $("#status-area").removeClass()
+    $("#status-area").show()
+    $("#status-area").addClass("alert "+style+" alert-dismissable fade show");
+    $("#alert-message").text(text);
+
     if ( extraText.length > 0) {
-        extraText = '<a href="" id="hideDetailsLink" class="alert-link" \
-                onclick="showHideText(\'showDetailsLink\',\'details\');return false;"> \
-                Hide Details</a> '+extraText ;
-        extraText = '<div id="details" style="display:none">' + extraText + '</div>';
+        $("#details-area").show();
+        $("#detail-message").text(extraText);
+    } else {
+        $("#detail-message").text(extraText);
+        $("#details-area").hide();
     }
 
-    var returnText = '<div id="alert-msg" class="alert '+style+' alert-dismissable fade show" \
-        role="alert">'
-        + text
-        + '<button type="button" class="close" data-dismiss="alert" aria-label="Close"> \
-        <span aria-hidden="true">&times;</span></button> '
-        + ( (extraText.length > 0) ? ' <hr> <a href="" id="showDetailsLink" class="alert-link" \
-            onclick="showHideText(\'details\',\'showDetailsLink\');return false;"> \
-            Show Details</a> ' : '' )
-        + extraText
-        +'</div>';
+    $(".alert").alert()
 
-    return returnText;
+    $("#close-alert-btn").click(function() {
+        $("#alert-message").text('');
+        $(this).parent().hide();
+    });
 }
 
 /**
@@ -276,20 +276,19 @@ var validate = function(filename) {
   var code = document.getElementById("code").value;
 
   // Clear the status area:
-  var statusArea = document.getElementById("status-area");
-  statusArea.innerHTML = getAlertFor("Validating ...", "alert-info") ;
+  showAlertFor("Validating ...", "alert-info") ;
 
   // Before doing anything else, make sure that the idspace indicated in the code matches the
   // idspace being edited:
   var expected_idspace = filename.toUpperCase().replace(".YML", "");
   var actual_idspace = code.match(/[^\S\r\n]*idspace:[^\S\r\n]+(.+?)[^\S\r\n]*\n/m);
   if (!actual_idspace) {
-    statusArea.innerHTML = getAlertFor("Validation failed: \'idspace: \' is required", "alert-danger") ;
+    showAlertFor("Validation failed: \'idspace: \' is required", "alert-danger") ;
     get_commit_btn().disabled = true;
     return;
   }
   else if (actual_idspace[1] !== expected_idspace) {
-    statusArea.innerHTML = getAlertFor("Validation failed: \'idspace: " + actual_idspace[1] +
+    showAlertFor("Validation failed: \'idspace: " + actual_idspace[1] +
       "\' does not match expected idspace: \'" + expected_idspace + "\'", "alert-danger")  ;
     get_commit_btn().disabled = true;
     return;
@@ -302,11 +301,11 @@ var validate = function(filename) {
     $("*").css("cursor", "default");
     if (request.readyState === 4) {
       if (!request.status) {
-        statusArea.innerHTML = getAlertFor("Problem communicating with server","alert-danger");
+        showAlertFor("Problem communicating with server","alert-danger");
         get_commit_btn().disabled = true;
       }
       else if (request.status === 200) {
-        statusArea.innerHTML = getAlertFor("Validation successful", "alert-success") ;
+        showAlertFor("Validation successful", "alert-success") ;
         get_commit_btn().disabled = false;
       }
       else {
@@ -319,8 +318,7 @@ var validate = function(filename) {
         alertText = alertText.replace(/</g, '&lt;').replace(/>/g, '&gt;');
         alertTextDetail = response.details + '\n';
         alertTextDetail = alertTextDetail.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-        alertTextDetail = '<div class="preformatted">'+alertTextDetail+'</div>';
-        statusArea.innerHTML = getAlertFor(alertText,"alert-danger",alertTextDetail);
+        showAlertFor(alertText,"alert-danger",alertTextDetail);
         get_commit_btn().disabled = true;
         // If the line number is valid, then add it to the message and highlight that line in the
         // editor while scrolling it into view.

--- a/templates/purl_editor.jinja2
+++ b/templates/purl_editor.jinja2
@@ -78,6 +78,27 @@
   </div>
 
   <!-- Messages received when pressing the 'Validate' button are displayed in this div. -->
-  <div id="status-area"/>
+  <div id="status-area" role="alert" style="display:none" >
+    <button id="close-alert-btn" type="button" class="close" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+    </button>
+    <div id="alert-message"> <!-- For the main validation message. -->
+    </div>
 
+    <div id="details-area" style="display:none">
+        <hr/>
+        <a href="" id="showDetailsLink" class="alert-link" onclick="showHideText('details','showDetailsLink');return false;">
+            Show Details
+        </a>
+
+        <div id="details" style="display:none">
+            <a href="" id="hideDetailsLink" class="alert-link" onclick="showHideText('showDetailsLink','details');return false;">
+                Hide Details
+            </a>
+            <div id="detail-message" class="preformatted">  <!-- for the secondary message. -->
+            </div>
+        </div> <!-- details -->
+    </div> <!-- details-area -->
+  </div> <!-- status-area -->
+</div>
 </div>

--- a/templates/purl_editor.jinja2
+++ b/templates/purl_editor.jinja2
@@ -2,15 +2,13 @@
 <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
 <meta content="utf-8" http-equiv="encoding">
 
-<script type="text/javascript" src="https://code.jquery.com/jquery-3.3.1.js"
-	      integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60="
-	      crossorigin="anonymous">
-</script>
-
 <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
       rel="stylesheet" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh"
       crossorigin="anonymous"/>
 
+<script type="text/javascript" src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous">
+</script>
+    <script type="text/javascript"src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
 <script type="text/javascript" src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.bundle.min.js"
         integrity="sha384-6khuMg9gaYr5AxOqhkVIODVIvm9ynTT5J4V1cfthmT+emCG6yVmEZsRHdxlotUnm"
         crossorigin="anonymous">


### PR DESCRIPTION
Closes #3 

- Hide validation details by default, toggled with "Show details"/"Hide details" link
- Validation error message now uses  Bootstrap alert theme
- Fix problem with validation of idspace if not on first line of file (it still checks that it is at the start of a line)

