### PR TITLE
Change theme to be similar to obofoundry theme

### DIFF
--- a/purl_editor.css
+++ b/purl_editor.css
@@ -1,3 +1,9 @@
+body {
+  margin-top: 25px;
+  margin-left: 75px;
+  margin-right: 75px;
+}
+
 caption {
     caption-side: top;
     font-weight: bold;
@@ -45,6 +51,6 @@ button:disabled {
     padding: 1em;
 }
 
-h2 {
+h1 {
     margin-top: 0.5em;
 }

--- a/templates/index.jinja2
+++ b/templates/index.jinja2
@@ -6,43 +6,68 @@
       rel="stylesheet" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh"
       crossorigin="anonymous"/>
 
+<script src="https://kit.fontawesome.com/f2901ed411.js" crossorigin="anonymous"></script>
+
 <link rel="stylesheet" href="/purl_editor.css"/>
 
-{% set appname = "OBO PURL YAML Code Editor" %}
+{% set appname = "OBO Metadata Editor" %}
 
 <title>{{ appname }}</title>
 
-<div class="container-fluid">
+<div class="content">
 
-  <h2><a href="/">{{ appname }}</a></h2>
+    <h1><a href="/" class="text-dark">{{ appname }}</a></h1>
 
-  {% if login is not none %}
-    <div>
-      You are logged in as <strong>{{ login }}</strong>.
-      Click <a href="/logout">here</a> to logout
+    {% if login is not none %}
+        <div>
+        You are logged in as <strong>{{ login }}</strong>.
+        Click <a href="/logout">here</a> to logout
+        </div>
+    {% endif %}
+
+    <hr/>
+
+
+    <div class="alert alert-info" role="alert">
+        <p>This OBO Metadata Editor is a tool for editing the metadata associated with OBO Foundry ontologies.</p>
+
+        <p>The PURL configuration for each ontology is specified in a YAML configuration file.</p>
+
+        <p>Choose one of the project configurations below to edit, or
+        <a href="/prepare_new" class="alert-link">add a new project configuration</a>.</p>
     </div>
-  {% endif %}
 
-  <hr/>
-</div>
+    <div class="col-md-12">
+        <div class="row">
+            <div class="col-md-12">
+            <table class="table small">
+                <tbody>
+                {% for cfg in configs | sort(attribute='name') %}
+                    <tr>
+                    <td>
+                        <a href="{{cfg.url}}">{{ cfg.name | replace(".yml", "")}}</a>
+                    </td>
+                    <td>
+                        {{ cfg.title }}
+                    </td>
+                    <td>
+                        {{ cfg.description }}
+                    </td>
+                    <td style="min-width:100px">
+                        <a href="/edit/{{ cfg.path }}">
+                            <button type="button" class="btn btn-light border border-secondary" aria-label="Left Align" title="Edit PURL config">
+                            <span class="small" style="white-space: nowrap;">
+                            <i class="fas fa-pencil-alt"></i>
+                            Edit PURL</span>
+                            </button>
+                        </a>
+                    </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+            </div>
+        </div>
+    </div>
 
-<div class="col-sm-6">
-  <table class="table table-striped table-bordered">
-    <caption>
-      Choose one of the project configurations below to edit, or
-      <a href="/prepare_new">add a new project configuration</a>.
-    </caption>
-    <tbody>
-      {% for cfg in configs | sort(attribute='name') %}
-        <tr>
-          <td>
-            <a href="/edit/{{ cfg.path }}">{{ cfg.name | replace(".yml", "") | upper }}</a>
-          </td>
-          <td>
-            {{ cfg.title }}
-          </td>
-        </tr>
-      {% endfor %}
-    </tbody>
-  </table>
 </div>

--- a/templates/index.jinja2
+++ b/templates/index.jinja2
@@ -28,14 +28,9 @@
     <hr/>
 
 
-    <div class="alert alert-info" role="alert">
-        <p>This OBO Metadata Editor is a tool for editing the metadata associated with OBO Foundry ontologies.</p>
 
-        <p>The PURL configuration for each ontology is specified in a YAML configuration file.</p>
-
-        <p>Choose one of the project configurations below to edit, or
-        <a href="/prepare_new" class="alert-link">add a new project configuration</a>.</p>
-    </div>
+    <p>Choose one of the project configurations below to edit, or
+    <a href="/prepare_new" class="text-primary">add a new project configuration</a>.</p>
 
     <div class="col-md-12">
         <div class="row">

--- a/templates/index.jinja2
+++ b/templates/index.jinja2
@@ -50,10 +50,10 @@
                     </td>
                     <td style="min-width:100px">
                         <a href="/edit/{{ cfg.path }}">
-                            <button type="button" class="btn btn-light border border-secondary" aria-label="Left Align" title="Edit PURL config">
+                            <button type="button" class="btn btn-light border border-secondary" aria-label="Left Align" title="Edit PURLs">
                             <span class="small" style="white-space: nowrap;">
                             <i class="fas fa-pencil-alt"></i>
-                            Edit PURL</span>
+                            Edit PURLs</span>
                             </button>
                         </a>
                     </td>

--- a/templates/logged_out.jinja2
+++ b/templates/logged_out.jinja2
@@ -8,13 +8,13 @@
 
 <link rel="stylesheet" href="/purl_editor.css"/>
 
-{% set appname = "OBO PURL YAML Code Editor" %}
+{% set appname = "OBO Metadata Editor" %}
 
 <title>{{ appname }}</title>
 
 <div class="container-fluid">
 
-  <h2><a href="/">{{ appname }}</a></h2>
+  <h1><a href="/" class="text-dark">{{ appname }}</a></h1>
 
   <hr/>
   <div>

--- a/templates/prepare_new_config.jinja2
+++ b/templates/prepare_new_config.jinja2
@@ -8,13 +8,13 @@
 
 <link rel="stylesheet" href="/purl_editor.css"/>
 
-{% set appname = "OBO PURL YAML Code Editor" %}
+{% set appname = "OBO Metadata Editor" %}
 
 <title>{{ appname }}</title>
 
 <div class="container-fluid">
 
-  <h2><a href="/">{{ appname }}</a></h2>
+  <h1><a href="/" class="text-dark">{{ appname }}</a></h1>
 
   {% if login is not none %}
     <div>

--- a/templates/purl_editor.jinja2
+++ b/templates/purl_editor.jinja2
@@ -35,13 +35,13 @@
 <script type="text/javascript" src="/purl_editor.js" defer></script>
 <link rel="stylesheet" href="/purl_editor.css"/>
 
-{% set appname = "OBO PURL YAML Code Editor" %}
+{% set appname = "OBO Metadata Editor" %}
 
 <title>{{ appname }}</title>
 
 <div class="container-fluid">
 
-  <h2><a href="/">{{ appname }}</a></h2>
+  <h1><a href="/" class="text-dark">{{ appname }}</a></h1>
 
   {% if login is not none %}
     <div>


### PR DESCRIPTION
Closes #5 

Change styling of home page to be more similar to obofoundry.org:

    Add an information box above the main table
    Show ontology IDs in lowercase, link to ontology file rather than edit page
    Add ontology description as a separate column
    Add 'Edit PURL' button which links to the edit page

Note that I could not work out how to include the Jekyll styles in a non-Jekyll-generated website, but perhaps with the Bootstrap styling alone it is close enough?