### PR TITLE
Link to OBO Foundry page for each ontology rather than OWL file

### DIFF
--- a/server.py
+++ b/server.py
@@ -222,13 +222,10 @@ def index():
     if config_id != "obo":
       config_title = [o['title'] for o in ontology_md if o['id'] == config_id]
       config_title = config_title.pop() if config_title else ""
-      config_url = [o['ontology_purl'] for o in ontology_md if o['id'] == config_id and 'ontology_purl' in o]
-      config_url = config_url.pop() if config_url else ""
       config_description = [o['description'] for o in ontology_md if o['id'] == config_id and 'description' in o]
       config_description = config_description.pop() if config_description else ""
       configs.append(
-        {'name': full_config['name'], 'path': full_config['path'], 'title': config_title,
-         'url': config_url, 'description': config_description})
+        {'name': full_config['name'], 'path': full_config['path'], 'title': config_title, 'description': config_description})
 
   return render_template('index.jinja2', configs=configs, login=g.user.github_login)
 

--- a/templates/index.jinja2
+++ b/templates/index.jinja2
@@ -40,7 +40,7 @@
                 {% for cfg in configs | sort(attribute='name') %}
                     <tr>
                     <td>
-                        <a href="{{cfg.url}}">{{ cfg.name | replace(".yml", "")}}</a>
+                        <a href="http://obofoundry.org/ontology/{{cfg.name | replace('.yml', '.html')}}" target="_new">{{ cfg.name | replace(".yml", "")}}</a>
                     </td>
                     <td>
                         {{ cfg.title }}


### PR DESCRIPTION
Ontology ID on index page link to OBO Foundry ontology page rather than the ontology OWL file. 

Also made the link open in a new tab rather than in the current one. 

Closes #15 