### PR TITLE
Change project name on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# OBO PURL YAML Code Editor
+# OBO Metadata Editor
 
-A web based editor for modifying existing and creating new OBO PURL YAML configurations.
+A web based editor for modifying existing and creating new OBO Metadata configurations.
 
 ## Before running the server:
 


### PR DESCRIPTION
An addendum to the renaming of the project files from purl_editor* to editor_*: 

Rename the project name in the README.md file. 

