### PR TITLE
Fix bug with Bootbox in templates

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -29,11 +29,11 @@ function showAlertFor(text, style, extraText='') {
     $("#status-area").removeClass()
     $("#status-area").show()
     $("#status-area").addClass("alert "+style+" alert-dismissable fade show");
-    $("#alert-message").text(text);
+    $("#alert-message").html(text);
 
     if ( extraText.length > 0) {
         $("#details-area").show();
-        $("#detail-message").text(extraText);
+        $("#detail-message").html(extraText);
     } else {
         $("#detail-message").text(extraText);
         $("#details-area").hide();
@@ -411,10 +411,7 @@ var add_config = function(filename) {
         // Extract the code from the text area:
         var code = document.getElementById("code").value;
 
-        // Clear the status area:
-        var statusArea = document.getElementById("status-area");
-        statusArea.style.color = "#000000";
-        statusArea.innerHTML = "Submitting new configuration ...";
+        showAlertFor("Submitting new configuration ...","alert-info");
 
         // Embed the code into a request.
         var request = new XMLHttpRequest();
@@ -423,26 +420,22 @@ var add_config = function(filename) {
           $("*").css("cursor", "default");
           if (request.readyState === 4) {
             if (!request.status) {
-              statusArea.style.color = "#FF0000";
-              statusArea.innerHTML = "Problem communicating with server";
+              showAlertFor("Problem communicating with server","alert-danger");
             }
             else if (request.status === 200) {
               var response = JSON.parse(request.responseText);
               var prInfo = response['pr_info'];
-              statusArea.style.color = "#00CD00";
-              statusArea.innerHTML = 'New configuration submitted successfully. It will be ' +
+              showAlertFor('New configuration submitted successfully. It will be ' +
                 'reviewed by a moderator before being added to the repository. Click ' +
                 '<a href="' + prInfo['html_url'] + '" target="__blank">here</a> to view your ' +
-                'pull request on GitHub.';
+                'pull request on GitHub.',"alert-success");
             }
             else {
               // Display the error message in the status area. Note that we must replace any angle
               // angle brackets with HTML escape codes.
               alertText = "Submission of new configuration failed.\n\n" +
                 request.responseText.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-              alertText = '<div class="preformatted">' + alertText + '</div>';
-              statusArea.style.color = "#FF0000";
-              statusArea.innerHTML = alertText;
+              showAlertFor(alertText,"alert-danger");
             }
           }
         }
@@ -494,10 +487,7 @@ var update_config = function(filename) {
         // Extract the code from the text area:
         var code = document.getElementById("code").value;
 
-        // Clear the status area:
-        var statusArea = document.getElementById("status-area");
-        statusArea.style.color = "#000000";
-        statusArea.innerHTML = "Submitting update ...";
+        showAlertFor("Submitting update ...","alert-info");
 
         // Embed the code into a request.
         var request = new XMLHttpRequest();
@@ -506,26 +496,22 @@ var update_config = function(filename) {
           $("*").css("cursor", "default");
           if (request.readyState === 4) {
             if (!request.status) {
-              statusArea.style.color = "#FF0000";
-              statusArea.innerHTML = "Problem communicating with server";
+              showAlertFor("Problem communicating with server","alert-danger");
             }
             else if (request.status === 200) {
               var response = JSON.parse(request.responseText);
               var prInfo = response['pr_info'];
-              statusArea.style.color = "#00CD00";
-              statusArea.innerHTML = 'Update submitted successfully. The changes will be ' +
+              showAlertFor('Update submitted successfully. The changes will be ' +
                 'reviewed by a moderator before being added to the repository. Click ' +
                 '<a href="' + prInfo['html_url'] + '" target="__blank">here</a> to view your ' +
-                'pull request on GitHub.';
+                'pull request on GitHub.',"alert-success");
             }
             else {
               // Display the error message in the status area. Note that we must replace any angle
               // angle brackets with HTML escape codes.
               alertText = "Submission of update failed.\n\n" +
                 request.responseText.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-              alertText = '<div class="preformatted">' + alertText + '</div>';
-              statusArea.style.color = "#FF0000";
-              statusArea.innerHTML = alertText;
+              showAlertFor(alertText,"alert-danger");
             }
           }
         }

--- a/templates/base.jinja2
+++ b/templates/base.jinja2
@@ -47,7 +47,10 @@
     <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
-
+    <!-- Bootbox -->
+    <script type="text/javascript"
+            src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js">
+    </script>
     <!-- FontAwesome (for icons) -->
     <script src="https://kit.fontawesome.com/f2901ed411.js" crossorigin="anonymous"></script>
 

--- a/templates/editor.jinja2
+++ b/templates/editor.jinja2
@@ -1,11 +1,6 @@
 {% extends "base.jinja2" %}
 
 {% block html_head %}
-
-    <!-- Bootbox -->
-    <script type="text/javascript"
-            src="https://cdnjs.cloudflare.com/ajax/libs/bootbox.js/5.4.0/bootbox.min.js">
-    </script>
     <!-- CodeMirror -->
     <link rel="stylesheet" href="/3pp/codemirror/lib/codemirror.css"/>
     <link rel="stylesheet" href="/3pp/codemirror/addon/display/fullscreen.css"/>
@@ -74,7 +69,6 @@
         </div> <!-- details -->
     </div> <!-- details-area -->
   </div> <!-- status-area -->
-</div>
 
 
 {% endblock %}


### PR DESCRIPTION
There was a bug with the implementation of the base and inherited templates that prevented Bootbox dialogs from being displayed, as the JavaScript wasn't loaded in the right sequence. This commit fixes it. 