### PR TITLE
Add OBO registry config file editing (in development mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# OBO PURL YAML Code Editor
+# OBO Metadata Editor
 
-A web based editor for modifying existing and creating new OBO PURL YAML configurations.
+A web based editor for modifying existing and creating new OBO Metadata configurations.
 
 ## Before running the server:
 
@@ -18,7 +18,7 @@ pip install -r requirements.txt
 To obtain the values for the first two settings, send an email to james@overton.ca. For the value of `FLASK_SECRET_KEY`, a randomly generated string may be used.
 
 3. Edit the file `config.py` and make sure that the configuration settings are correct. Note in particular the settings for `FLASK_PORT`, `LOG_LEVEL`, `GITHUB_ORG`, `SCHEMAFILE`, and `ONTOLOGY_METADATA_URL`.
-- `LOG_LEVEL` should be set to one of: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (_without_ quotes).
+- `LOG_LEVEL` should be set to one of: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (_without_ quotes). Note that setting logging to DEBUG will only be effective if FLASK_ENV is set to `development` (the default is `production`)
 - `FLASK_PORT` should be set to the port on which the server will be listening.
 - `GITHUB_ORG` should be set to the organization or username that owns the repository. Normally it should be set to `OBOFoundry`.
 - `SCHEMAFILE` is the location of the jsonschema file that will be used to validate YAML code.
@@ -30,5 +30,6 @@ To obtain the values for the first two settings, send an email to james@overton.
 ```
 export FLASK_APP=server.py
 export FLASK_DEBUG=1 (optional)
+export FLASK_ENV=development (optional)
 python3 -m flask run
 ```

--- a/config.py
+++ b/config.py
@@ -18,8 +18,12 @@ PWD = os.path.dirname(os.path.realpath(__file__))
 GITHUB_ORG = 'OBOFoundry'
 # The github repository to use for editing PURL configuration (e.g. 'purl.obolibrary.org')
 GITHUB_PURL_REPO = 'purl.obolibrary.org'
-# The github repository to use for editing Foundry metadata (e.g. 'OBOFoundry.github.io')
+# The directory in which the PURL config files are stored within the PURL repo
+GITHUB_PURL_DIR = 'config'
+# The github repository to use for editing Foundry registry (e.g. 'OBOFoundry.github.io')
 GITHUB_FOUNDRY_REPO = 'OBOFoundry.github.io'
+# The directory in which the Registry config files within the Foundry repo
+GITHUB_FOUNDRY_DIR = 'ontology'
 
 # The location of the PURL validation schema:
 PURL_SCHEMA = "{}/../purl.obolibrary.org/tools/config.schema.json".format(PWD)

--- a/config.py
+++ b/config.py
@@ -11,16 +11,18 @@ LOGGING_CONFIG = '%(asctime)-15s %(name)s %(levelname)s - %(message)s'
 FLASK_HOST = ''
 FLASK_PORT = 5000
 
-# The filesystem directory where purl-edtor is running from:
+# The filesystem directory where the metadata editor is running from:
 PWD = os.path.dirname(os.path.realpath(__file__))
 
 # The github organisation/username to use when communicating with github (e.g. 'OBOFoundry')
-GITHUB_ORG = 'lmcmicu'
-# The github repository to use when communicating with github (e.g. 'purl.obolibrary.org')
-GITHUB_REPO = 'purl.obolibrary.org'
+GITHUB_ORG = 'OBOFoundry'
+# The github repository to use for editing PURL configuration (e.g. 'purl.obolibrary.org')
+GITHUB_PURL_REPO = 'purl.obolibrary.org'
+# The github repository to use for editing Foundry metadata (e.g. 'OBOFoundry.github.io')
+GITHUB_FOUNDRY_REPO = 'OBOFoundry.github.io'
 
-# The location of the validation schema:
-SCHEMAFILE = "{}/../purl.obolibrary.org/tools/config.schema.json".format(PWD)
+# The location of the PURL validation schema:
+PURL_SCHEMA = "{}/../purl.obolibrary.org/tools/config.schema.json".format(PWD)
 
 # The URL where information (e.g. long names) about ontologies can be retrieved.
 ONTOLOGY_METADATA_URL = \
@@ -38,9 +40,9 @@ GITHUB_OAUTH_STATE = os.getenv('GITHUB_OAUTH_STATE')
 GITHUB_CLIENT_ID = os.getenv('GITHUB_CLIENT_ID')
 GITHUB_CLIENT_SECRET = os.getenv('GITHUB_CLIENT_SECRET')
 
-# Template used to generate the initial text when launching the editor with a new configuration
+# Template used to generate the initial text when launching the editor with a new PURL configuration
 # file:
-NEW_PROJECT_TEMPLATE = textwrap.dedent(
+NEW_PROJECT_PURL_TEMPLATE = textwrap.dedent(
   """
   # PURL configuration for http://purl.obolibrary.org/obo/{idspace_lower}
 

--- a/config.py
+++ b/config.py
@@ -25,6 +25,11 @@ GITHUB_FOUNDRY_REPO = 'OBOFoundry.github.io'
 # The directory in which the Registry config files within the Foundry repo
 GITHUB_FOUNDRY_DIR = 'ontology'
 
+# File extension for YAML files
+YAML_EXT = ".yml"
+# File extension for Markdown files
+MARKDOWN_EXT = ".md"
+
 # The location of the PURL validation schema:
 PURL_SCHEMA = "{}/../purl.obolibrary.org/tools/config.schema.json".format(PWD)
 

--- a/editor.js
+++ b/editor.js
@@ -379,10 +379,10 @@ var validate = function(filename) {
 /**
  * Submit a pull request to github to add a new configuration to the repository.
  */
-var add_config = function(filename) {
+var add_config = function(filename, repo) {
   // Get a confirmation from the user:
   bootbox.prompt({
-    title: "Please describe the new configuration you would like to add: " +
+    title: "Please describe the new configuration you would like to add to "+repo+": " +
       filename.toUpperCase().replace(".YML", ""),
     inputType: 'textarea',
     value: 'Adding ' + filename,
@@ -455,10 +455,10 @@ var add_config = function(filename) {
 /**
  * Submit a pull request to github to update the given configuration file in the repository.
  */
-var update_config = function(filename) {
+var update_config = function(filename,repo) {
   // Get a confirmation from the user:
   bootbox.prompt({
-    title: "Please describe the changes you have made to " +
+    title: "You are about to submit changes to "+repo+". Please describe the changes you have made to " +
       filename.toUpperCase().replace(".YML", ""),
     inputType: 'textarea',
     value: 'Updating ' + filename,
@@ -520,7 +520,8 @@ var update_config = function(filename) {
         request.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
         request.send('filename=' + filename +
                      '&commit_msg=' + commit_msg +
-                     '&code=' + encodeURIComponent(code))
+                     '&code=' + encodeURIComponent(code) +
+                     '&repo='+repo)
         $("*").css("cursor", "progress");
       }
     }

--- a/editor.js
+++ b/editor.js
@@ -311,7 +311,7 @@ var validate = function(filename) {
 
   // Before doing anything else, make sure that the idspace indicated in the code matches the
   // idspace being edited:
-  var expected_idspace = filename.toUpperCase().replace(".YML", "");
+  var expected_idspace = filename.toUpperCase().substring(0, filename.lastIndexOf('.'));
   var actual_idspace = code.match(/[^\S\r\n]*idspace:[^\S\r\n]+(.+?)[^\S\r\n]*\n/m);
   if (!actual_idspace) {
     showAlertFor("Validation failed: \'idspace: \' is required", "alert-danger") ;
@@ -383,7 +383,7 @@ var add_config = function(filename, editor_type) {
   // Get a confirmation from the user:
   bootbox.prompt({
     title: "Please describe the new configuration you would like to add: " +
-      filename.toUpperCase().replace(".YML", ""),
+      filename.toUpperCase().substring(0, filename.lastIndexOf('.')),
     inputType: 'textarea',
     value: 'Adding ' + filename,
     buttons: {
@@ -460,7 +460,7 @@ var update_config = function(filename,editor_type) {
   // Get a confirmation from the user:
   bootbox.prompt({
     title: "You are about to submit changes. Please describe the changes you have made to " +
-      filename.toUpperCase().replace(".YML", ""),
+      filename.toUpperCase().substring(0, filename.lastIndexOf('.')),
     inputType: 'textarea',
     value: 'Updating ' + filename,
     buttons: {

--- a/editor.js
+++ b/editor.js
@@ -379,10 +379,10 @@ var validate = function(filename) {
 /**
  * Submit a pull request to github to add a new configuration to the repository.
  */
-var add_config = function(filename, repo) {
+var add_config = function(filename, editor_type) {
   // Get a confirmation from the user:
   bootbox.prompt({
-    title: "Please describe the new configuration you would like to add to "+repo+": " +
+    title: "Please describe the new configuration you would like to add: " +
       filename.toUpperCase().replace(".YML", ""),
     inputType: 'textarea',
     value: 'Adding ' + filename,
@@ -444,7 +444,8 @@ var add_config = function(filename, repo) {
         request.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
         request.send('filename=' + filename +
                      '&commit_msg=' + commit_msg +
-                     '&code=' + encodeURIComponent(code))
+                     '&code=' + encodeURIComponent(code) +
+                     '&editor_type=' + editor_type)
         $("*").css("cursor", "progress");
       }
     }
@@ -455,10 +456,10 @@ var add_config = function(filename, repo) {
 /**
  * Submit a pull request to github to update the given configuration file in the repository.
  */
-var update_config = function(filename,repo) {
+var update_config = function(filename,editor_type) {
   // Get a confirmation from the user:
   bootbox.prompt({
-    title: "You are about to submit changes to "+repo+". Please describe the changes you have made to " +
+    title: "You are about to submit changes. Please describe the changes you have made to " +
       filename.toUpperCase().replace(".YML", ""),
     inputType: 'textarea',
     value: 'Updating ' + filename,
@@ -521,7 +522,7 @@ var update_config = function(filename,repo) {
         request.send('filename=' + filename +
                      '&commit_msg=' + commit_msg +
                      '&code=' + encodeURIComponent(code) +
-                     '&repo='+repo)
+                     '&editor_type='+editor_type)
         $("*").css("cursor", "progress");
       }
     }

--- a/server.py
+++ b/server.py
@@ -247,7 +247,7 @@ def index():
         registries_for_idspace = [x for x in registry_configs if x['name'] == config_id + app.config["MARKDOWN_EXT"]]
 
       configs.append(
-        {'purl_filename': purl_config['name'],
+        {'id': config_id, 'purl_filename': purl_config['name'],
          'registry_filename': registries_for_idspace[0]['name'] if dev and len(registries_for_idspace)>0 else None,
          'title': config_title, 'description': config_description})
 

--- a/server.py
+++ b/server.py
@@ -55,6 +55,14 @@ db_session = scoped_session(sessionmaker(autocommit=False,
 Base = declarative_base()
 Base.query = db_session.query_property()
 
+# Boolean for managing current running state feature (show/hide in-development features)
+dev = app.config["ENV"]=='development'
+
+
+# Utility dictionary for linking editor types to repositories and content directories
+editor_types = {"purl": {"repo":app.config["GITHUB_PURL_REPO"],"dir":app.config["GITHUB_PURL_DIR"]},
+                "registry": {"repo":app.config["GITHUB_FOUNDRY_REPO"],"dir":app.config["GITHUB_FOUNDRY_DIR"]}}
+
 
 # Retrieve the ontology metadata:
 try:
@@ -209,24 +217,39 @@ def index():
   Renders the index page of the application
   """
   # Get all of the available config files to edit:
-  full_configs = github.get('repos/{}/{}/contents/config'
-                            .format(app.config['GITHUB_ORG'], app.config['GITHUB_PURL_REPO']))
-  if not full_configs:
-    raise Exception("Could not get contents of the config directory")
+  purl_configs = github.get('repos/{}/{}/contents/{}'.format(app.config['GITHUB_ORG'],
+                            editor_types['purl']['repo'], editor_types['purl']['dir']))
+  if not purl_configs:
+    raise Exception("Could not get contents of the purl config directory")
 
-  # Add the title, url and description for each config to the records that will be rendered. This information is found in the
-  # ontology metadata.
+  if dev:
+    # Get all of the available registry config files to edit:
+    registry_configs = github.get('repos/{}/{}/contents/{}'.format(app.config['GITHUB_ORG'],
+                                  editor_types['registry']['repo'],editor_types['registry']['dir']))
+    if not registry_configs:
+      raise Exception("Could not get contents of the registry config directory")
+
+  # TODO: Currently this adds entries to the table if they are in the PURL repository,
+  # TODO: which should be changed to include registry-only entries.
+
+  # Add the title, url and description for each config to the records that will be rendered.
+  # This information is found in the ontology metadata.
   configs = []
-  for full_config in full_configs:
-    config_id = full_config['name'].casefold().replace(".yml", "")
+  for purl_config in purl_configs:
+    config_id = purl_config['name'].casefold().replace(".yml", "")
     # We skip the OBO idspace:
     if config_id != "obo":
       config_title = [o['title'] for o in ontology_md if o['id'] == config_id]
       config_title = config_title.pop() if config_title else ""
       config_description = [o['description'] for o in ontology_md if o['id'] == config_id and 'description' in o]
       config_description = config_description.pop() if config_description else ""
+      if dev and registry_configs:
+        registries_for_idspace = [x for x in registry_configs if x['name'] == config_id + ".md"]
+
       configs.append(
-        {'name': full_config['name'], 'path': full_config['path'], 'title': config_title, 'description': config_description})
+        {'name': purl_config['name'], 'purl_path': purl_config['path'],
+         'registry_path': registries_for_idspace[0]['path'] if dev and len(registries_for_idspace)>0 else None,
+         'title': config_title, 'description': config_description})
 
   return render_template('index.jinja2', configs=configs, login=g.user.github_login)
 
@@ -291,15 +314,18 @@ def prepare_new():
   return render_template('prepare_new_config.jinja2', login=g.user.github_login)
 
 
-@app.route('/edit/<path:path>')
+@app.route('/edit/<editor_type>/<path:path>')
 @verify_logged_in
-def edit_config(path):
+def edit_config(path, editor_type):
   """
-  Get the contents of the given path from the github repository and render it in the
-  editor using the jinja2 template for the metadata editor
+  Get the contents of the given path (purl or registry) from the github repository
+  and render it in the editor using the jinja2 template for the metadata editor
   """
+  if editor_type not in editor_types.keys():
+    raise Exception("Unknown metadata type: {}".format(editor_type))
+
   config_file = github.get(
-    'repos/{}/{}/contents/{}'.format(app.config['GITHUB_ORG'], app.config['GITHUB_PURL_REPO'], path))
+      'repos/{}/{}/contents/{}'.format(app.config['GITHUB_ORG'], editor_types[editor_type]['repo'], path))
   if not config_file:
     raise Exception("Could not get the contents of: {}".format(path))
 
@@ -307,8 +333,8 @@ def edit_config(path):
   decodedStr = str(decodedBytes, "utf-8")
   return render_template('editor.jinja2',
                          existing=True,
+                         editor_type=editor_type,
                          yaml=decodedStr,
-                         repo= '{}/{}'.format(app.config['GITHUB_ORG'], app.config['GITHUB_PURL_REPO']),
                          filename=config_file['name'],
                          login=g.user.github_login)
 
@@ -499,11 +525,11 @@ def add_config():
   filename = request.form.get('filename')
   code = request.form.get('code')
   commit_msg = request.form.get('commit_msg')
-  repo = request.form.get('repo')
-  if any([item is None for item in [filename, commit_msg, code]]):
+  editor_type = request.form.get('editor_type')
+  if any([item is None for item in [filename, commit_msg, code, editor_type]]):
     return Response("Malformed POST request", status=400)
 
-  # repo = '{}/{}'.format(app.config['GITHUB_ORG'], app.config['GITHUB_REPO'])
+  repo = '{}/{}'.format(app.config['GITHUB_ORG'], editor_types[editor_type]['repo'])
 
   try:
     master_sha = get_master_sha(repo)
@@ -525,19 +551,20 @@ def add_config():
 @verify_logged_in
 def update_config():
   """
-  Route for initiating a pull request to update a config file in the github repository.
+  Route for initiating a pull request to update a PURL config file in the github repository.
   """
   filename = request.form.get('filename')
   code = request.form.get('code')
   commit_msg = request.form.get('commit_msg')
-  repo = request.form.get('repo')
+  editor_type = request.form.get('editor_type')
 
-  if any([item is None for item in [filename, commit_msg, code]]):
+  if any([item is None for item in [filename, commit_msg, code, editor_type]]):
     return Response("Malformed POST request", status=400)
 
   # Get the contents of the current version of the file:
-  curr_contents = github.get('repos/{}/{}/contents/config/{}'
-                             .format(app.config['GITHUB_ORG'], app.config['GITHUB_PURL_REPO'], filename))
+  curr_contents = github.get('repos/{}/{}/contents/{}/{}'
+                             .format(app.config['GITHUB_ORG'], editor_types[editor_type]['repo'],
+                                     editor_types[editor_type]['dir'], filename))
   if not curr_contents:
     raise Exception("Could not get the contents of: {}".format(filename))
 
@@ -550,7 +577,7 @@ def update_config():
     return Response("Update request refused: The submitted configuration is identical to the "
                     "currently saved version.", status=422)
 
-  #repo = '{}/{}'.format(app.config['GITHUB_ORG'], app.config['GITHUB_PURL_REPO'])
+  repo = '{}/{}'.format(app.config['GITHUB_ORG'], editor_types[editor_type]['repo'])
 
   try:
     file_sha = get_file_sha(repo, filename)

--- a/server.py
+++ b/server.py
@@ -229,9 +229,6 @@ def index():
     if not registry_configs:
       raise Exception("Could not get contents of the registry config directory")
 
-  # TODO: Currently this adds entries to the table if they are in the PURL repository,
-  # TODO: which should be changed to include registry-only entries.
-
   # Add the title, url and description for each config to the records that will be rendered.
   # This information is found in the ontology metadata.
   configs = []
@@ -250,6 +247,19 @@ def index():
         {'id': config_id, 'purl_filename': purl_config['name'],
          'registry_filename': registries_for_idspace[0]['name'] if dev and len(registries_for_idspace)>0 else None,
          'title': config_title, 'description': config_description})
+  if dev:
+    for registry_config in registry_configs:
+      config_id = registry_config['name'].casefold().replace(app.config["MARKDOWN_EXT"], "")
+      if config_id not in [c['id'] for c in configs]:
+        config_title = [o['title'] for o in ontology_md if o['id'] == config_id]
+        config_title = config_title.pop() if config_title else ""
+        config_description = [o['description'] for o in ontology_md if o['id'] == config_id and 'description' in o]
+        config_description = config_description.pop() if config_description else ""
+        configs.append(
+          {'id': config_id, 'purl_filename': None,
+           'registry_filename': registry_config['name'],
+           'title': config_title, 'description': config_description})
+
 
   return render_template('index.jinja2', configs=configs, login=g.user.github_login)
 

--- a/server.py
+++ b/server.py
@@ -308,6 +308,7 @@ def edit_config(path):
   return render_template('editor.jinja2',
                          existing=True,
                          yaml=decodedStr,
+                         repo= '{}/{}'.format(app.config['GITHUB_ORG'], app.config['GITHUB_PURL_REPO']),
                          filename=config_file['name'],
                          login=g.user.github_login)
 
@@ -498,10 +499,11 @@ def add_config():
   filename = request.form.get('filename')
   code = request.form.get('code')
   commit_msg = request.form.get('commit_msg')
+  repo = request.form.get('repo')
   if any([item is None for item in [filename, commit_msg, code]]):
     return Response("Malformed POST request", status=400)
 
-  repo = '{}/{}'.format(app.config['GITHUB_ORG'], app.config['GITHUB_REPO'])
+  # repo = '{}/{}'.format(app.config['GITHUB_ORG'], app.config['GITHUB_REPO'])
 
   try:
     master_sha = get_master_sha(repo)
@@ -528,6 +530,7 @@ def update_config():
   filename = request.form.get('filename')
   code = request.form.get('code')
   commit_msg = request.form.get('commit_msg')
+  repo = request.form.get('repo')
 
   if any([item is None for item in [filename, commit_msg, code]]):
     return Response("Malformed POST request", status=400)
@@ -547,7 +550,7 @@ def update_config():
     return Response("Update request refused: The submitted configuration is identical to the "
                     "currently saved version.", status=422)
 
-  repo = '{}/{}'.format(app.config['GITHUB_ORG'], app.config['GITHUB_PURL_REPO'])
+  #repo = '{}/{}'.format(app.config['GITHUB_ORG'], app.config['GITHUB_PURL_REPO'])
 
   try:
     file_sha = get_file_sha(repo, filename)

--- a/templates/base.jinja2
+++ b/templates/base.jinja2
@@ -13,9 +13,13 @@
 
     <link rel="stylesheet" href="/editor.css"/>
 
-    <!-- shared between all pages -->
+    {% if config['ENV'] == 'development' %}
+        {% set dev = True %}
+    {% else %}
+        {% set dev = False %}
+    {% endif %}
 
-    {% set appname = "OBO Metadata Editor" %}
+    {% set appname = "OBO Metadata Editor <i>(development version)</i>" if dev else "OBO Metadata Editor" %}
 
     <title>{{ appname }}</title>
 

--- a/templates/editor.jinja2
+++ b/templates/editor.jinja2
@@ -37,10 +37,10 @@
     </button>
     {% if existing %}
       <button id="update-btn" class="btn btn-danger"
-              onclick="update_config('{{ filename }}')" disabled>Submit update
+              onclick="update_config('{{ filename }}', '{{ repo }}')" disabled>Submit update
       </button>
     {% else %}
-      <button id="add-btn" class="btn btn-danger" onclick="add_config('{{ filename }}')" disabled>
+      <button id="add-btn" class="btn btn-danger" onclick="add_config('{{ filename }}', '{{ repo }}')" disabled>
         Add configuration
       </button>
     {% endif %}

--- a/templates/editor.jinja2
+++ b/templates/editor.jinja2
@@ -21,7 +21,7 @@
   <h3>
     {% if existing %} Editing {% else %} Adding {% endif %}
     {% if dev %} {{ editor_type | upper }} {% endif %}
-    project configuration: {{ filename | upper | replace(".YML", "") }}</h3>
+    project configuration: {{ filename | upper | replace(".YML", "") | replace(".MD", "") }}</h3>
 
   <!-- Here is where the CodeMirror editor will live. This element is hidden but it will be used all
        the same to generate the CodeMirror editor.  -->

--- a/templates/editor.jinja2
+++ b/templates/editor.jinja2
@@ -19,11 +19,8 @@
 {% block content %}
 
   <h3>
-    {% if existing %}
-      Editing
-    {% else %}
-      Adding
-    {% endif %}
+    {% if existing %} Editing {% else %} Adding {% endif %}
+    {% if dev %} {{ editor_type | upper }} {% endif %}
     project configuration: {{ filename | upper | replace(".YML", "") }}</h3>
 
   <!-- Here is where the CodeMirror editor will live. This element is hidden but it will be used all
@@ -37,10 +34,10 @@
     </button>
     {% if existing %}
       <button id="update-btn" class="btn btn-danger"
-              onclick="update_config('{{ filename }}', '{{ repo }}')" disabled>Submit update
+              onclick="update_config('{{ filename }}', '{{ editor_type }}')" disabled>Submit update
       </button>
     {% else %}
-      <button id="add-btn" class="btn btn-danger" onclick="add_config('{{ filename }}', '{{ repo }}')" disabled>
+      <button id="add-btn" class="btn btn-danger" onclick="add_config('{{ filename }}', '{{ editor_type }}')" disabled>
         Add configuration
       </button>
     {% endif %}

--- a/templates/editor.jinja2
+++ b/templates/editor.jinja2
@@ -21,7 +21,8 @@
   <h3>
     {% if existing %} Editing {% else %} Adding {% endif %}
     {% if dev %} {{ editor_type | upper }} {% endif %}
-    project configuration: {{ filename | upper | replace(".YML", "") | replace(".MD", "") }}</h3>
+    {% set project_id = filename[ 0: filename.index(".") ] %}
+    project configuration: {{ project_id | upper }}</h3>
 
   <!-- Here is where the CodeMirror editor will live. This element is hidden but it will be used all
        the same to generate the CodeMirror editor.  -->

--- a/templates/index.jinja2
+++ b/templates/index.jinja2
@@ -54,13 +54,22 @@
                         {{ cfg.description }}
                     </td>
                     <td style="min-width:100px">
-                        <a href="/edit/{{ cfg.path }}">
+                        <a href="/edit/purl/{{ cfg.purl_path }}">
                             <button type="button" class="btn btn-light border border-secondary" aria-label="Left Align" title="Edit PURLs">
                             <span class="small" style="white-space: nowrap;">
                             <i class="fas fa-pencil-alt"></i>
                             Edit PURLs</span>
                             </button>
                         </a>
+                        {% if dev and cfg.registry_path %}
+                            <a href="/edit/registry/{{ cfg.registry_path }}">
+                                <button type="button" class="btn btn-light border border-secondary" aria-label="Left Align" title="Edit Registry">
+                                <span class="small" style="white-space: nowrap;">
+                                <i class="fas fa-pencil-alt"></i>
+                                Edit Registry Config</span>
+                                </button>
+                            </a>
+                        {% endif %}
                     </td>
                     </tr>
                 {% endfor %}

--- a/templates/index.jinja2
+++ b/templates/index.jinja2
@@ -55,14 +55,7 @@
                     </td>
                     <td style="min-width:100px white-space: nowrap;">
                         <div class="btn-group" role="group" aria-label="Edit Actions">
-                        <a href="/edit/purl/{{ cfg.purl_filename }}">
-                            <button type="button" class="btn btn-light border border-secondary" aria-label="Left Align" title="Edit PURLs">
-                            <span class="small" style="white-space: nowrap;">
-                            <i class="fas fa-pencil-alt"></i>
-                            Edit PURLs</span>
-                            </button>
-                        </a>
-                        {% if dev and cfg.registry_filename %}
+                          {% if dev and cfg.registry_filename %}
                             <a href="/edit/registry/{{ cfg.registry_filename }}">
                                 <button type="button" class="btn btn-light border border-secondary" aria-label="Left Align" title="Edit Registry">
                                 <span class="small" style="white-space: nowrap;">
@@ -70,8 +63,17 @@
                                 Edit Registry</span>
                                 </button>
                             </a>
+                          {% endif %}
+                          {% if cfg.purl_filename %}
+                            <a href="/edit/purl/{{ cfg.purl_filename }}">
+                                <button type="button" class="btn btn-light border border-secondary" aria-label="Left Align" title="Edit PURLs">
+                                <span class="small" style="white-space: nowrap;">
+                                <i class="fas fa-pencil-alt"></i>
+                                Edit PURLs</span>
+                                </button>
+                            </a>
+                          {% endif %}
                         </div>
-                        {% endif %}
                     </td>
                     </tr>
                 {% endfor %}

--- a/templates/index.jinja2
+++ b/templates/index.jinja2
@@ -42,10 +42,10 @@
             <div class="col-md-12">
             <table class="table small" id="tb-ontologies">
                 <tbody>
-                {% for cfg in configs | sort(attribute='title') %}
+                {% for cfg in configs | sort(attribute='id') %}
                     <tr>
                     <td>
-                        <a href="http://obofoundry.org/ontology/{{cfg.name | replace('.yml', '.html')}}" target="_new">{{ cfg.name | replace(".yml", "")}}</a>
+                        <a href="http://obofoundry.org/ontology/{{cfg.id}}.html" target="_new">{{ cfg.id }}</a>
                     </td>
                     <td>
                         {{ cfg.title }}

--- a/templates/index.jinja2
+++ b/templates/index.jinja2
@@ -42,7 +42,7 @@
             <div class="col-md-12">
             <table class="table small" id="tb-ontologies">
                 <tbody>
-                {% for cfg in configs | sort(attribute='name') %}
+                {% for cfg in configs | sort(attribute='title') %}
                     <tr>
                     <td>
                         <a href="http://obofoundry.org/ontology/{{cfg.name | replace('.yml', '.html')}}" target="_new">{{ cfg.name | replace(".yml", "")}}</a>
@@ -53,22 +53,24 @@
                     <td>
                         {{ cfg.description }}
                     </td>
-                    <td style="min-width:100px">
-                        <a href="/edit/purl/{{ cfg.purl_path }}">
+                    <td style="min-width:100px white-space: nowrap;">
+                        <div class="btn-group" role="group" aria-label="Edit Actions">
+                        <a href="/edit/purl/{{ cfg.purl_filename }}">
                             <button type="button" class="btn btn-light border border-secondary" aria-label="Left Align" title="Edit PURLs">
                             <span class="small" style="white-space: nowrap;">
                             <i class="fas fa-pencil-alt"></i>
                             Edit PURLs</span>
                             </button>
                         </a>
-                        {% if dev and cfg.registry_path %}
-                            <a href="/edit/registry/{{ cfg.registry_path }}">
+                        {% if dev and cfg.registry_filename %}
+                            <a href="/edit/registry/{{ cfg.registry_filename }}">
                                 <button type="button" class="btn btn-light border border-secondary" aria-label="Left Align" title="Edit Registry">
                                 <span class="small" style="white-space: nowrap;">
                                 <i class="fas fa-pencil-alt"></i>
-                                Edit Registry Config</span>
+                                Edit Registry</span>
                                 </button>
                             </a>
+                        </div>
                         {% endif %}
                     </td>
                     </tr>


### PR DESCRIPTION
This PR includes changes to add an OBO Registry editor option (visible in development mode only). This includes 
- Adding an additional repository for the registry markdown files
- Change URL pattern of edit page to include edit type: "purl" or "registry"
- Specify the directory where config files are stored in their repositories as a config parameter rather than hard-coded, and also take it out of the edit URL pattern
- Remove hard-coding of file extensions and add them as config parameters as well
- Show an edit button (Edit Registry) on the index page when in development mode
- Show registry-only ontologies (no PURLs) in the ontology table when in development mode

