### PR TITLE
Dynamic field name in schema validation

### DIFF
--- a/server.py
+++ b/server.py
@@ -457,7 +457,8 @@ def validate():
             status = 400
         else:
             status = 200
-        error_summary = err.schema.get("description") or err.message
+        err_field = list(err.absolute_path)[-1] # last entry
+        error_summary = f"'{err_field}' {(err.schema.get('description') or err.message)}"
         logger.debug(f"Determining line number for error: {list(err.absolute_path)}")
         start = 0
         if not err.absolute_path:


### PR DESCRIPTION
This PR adds the ability for JSON validation to dynamically determine the field name from the schema path for a validation error, rather than having the validation message include the field name as it was before. 

Ideally, this PR will only be merged in combination with the updated PURL schema in the purl.obolibrary.org repository. 

Closes #31 