### PR TITLE
Use single registry schema file for registry validations

### DIFF
--- a/config.py
+++ b/config.py
@@ -39,19 +39,8 @@ PURL_SCHEMA = (
 REGISTRY_SCHEMA_DIR = (
     f"https://github.com/{GITHUB_ORG}/{GITHUB_FOUNDRY_REPO}/raw/master/util/schema/"
 )
-# Individual REGISTRY validation schema files
-REGISTRY_SCHEMA_FILES = [
-    "aberowl_id.json",
-    "activity_status.json",
-    "contact.json",
-    "description.json",
-    "homepage.json",
-    "id.json",
-    "license-lite.json",
-    "license.json",
-    "products.json",
-    "title.json",
-]
+# REGISTRY validation schema file (now merged)
+REGISTRY_SCHEMA_FILES = ["registry_schema.json"]
 
 # The URL where information (e.g. long names) about ontologies can be retrieved.
 ONTOLOGY_METADATA_URL = (


### PR DESCRIPTION
Uses single registry schema file for registry config file validations, and for schema violations it detects level of error (error/warning/info) from within single schema file. For obsolete files, error level is "demoted": error-> warning, warning->info. 

Closes #32 